### PR TITLE
Ensure that error message is returned on 422 error

### DIFF
--- a/netcore10/src/redmine-netcore10-api/Extensions/HttpMessageResponseExtensions.cs
+++ b/netcore10/src/redmine-netcore10-api/Extensions/HttpMessageResponseExtensions.cs
@@ -82,7 +82,7 @@ namespace Redmine.Net.Api.Extensions
                         message = errors.Items.Aggregate(message, (current, error) => $"{current}{error.Info}{Environment.NewLine}");
                     }
 
-                    exceptionMessage = $"Request to {responseMessage.RequestMessage.RequestUri.AbsoluteUri} failed with {message}";
+                    exceptionMessage = $"Request to {responseMessage.RequestMessage.RequestUri.AbsoluteUri} failed with {message ?? responseString ?? responseMessage.ReasonPhrase}";
                     return new UnprocessableEntityException(exceptionMessage);
 
                 default:


### PR DESCRIPTION
In some cases no message is returned by the error which makes debugging difficult.
Fallback on other message in that case.