### PR TITLE
Enabled basic authentication by passing the ommited values.

### DIFF
--- a/src/Extensions/HttpClientExtensions.cs
+++ b/src/Extensions/HttpClientExtensions.cs
@@ -18,6 +18,7 @@ using System;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
+using System.Net.Http.Headers;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -49,6 +50,11 @@ namespace RedmineApi.Core.Extensions
             {
                 httpClient.DefaultRequestHeaders.Remove(headerName);
             }
+        }
+
+        public static void AddAuthentcation(this HttpClient httpClient, AuthenticationHeaderValue authenticationHeaderValue)
+        {
+            httpClient.DefaultRequestHeaders.Authorization = authenticationHeaderValue;
         }
 
         public static Task<HttpResponseMessage> PatchAsync(this HttpClient client, string requestUri, HttpContent content, CancellationToken cancellationToken)

--- a/src/RedmineHttpClient.cs
+++ b/src/RedmineHttpClient.cs
@@ -17,6 +17,7 @@
 using System;
 using System.Net;
 using System.Net.Http;
+using System.Net.Http.Headers;
 using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading;
@@ -61,6 +62,8 @@ namespace RedmineApi.Core
         public string ImpersonateUser { get; internal set; }
 
         public string ApiKey { get; internal set; }
+
+        internal AuthenticationHeaderValue Authentication { private get; set; }
 
         public void Dispose()
         {
@@ -190,7 +193,14 @@ namespace RedmineApi.Core
 
         private void SetHeaders()
         {
-            httpClient.AddRequestHeader(X_REDMINE_API_KEY, ApiKey);
+            if (!string.IsNullOrEmpty(ApiKey))
+            {
+                httpClient.AddRequestHeader(X_REDMINE_API_KEY, ApiKey); 
+            }
+            else
+            {
+                httpClient.AddAuthentcation(Authentication);
+            }
             httpClient.AddRequestHeader(X_REDMINE_SWITCH_USER, ImpersonateUser);
         }
     }

--- a/src/RedmineManager.cs
+++ b/src/RedmineManager.cs
@@ -68,6 +68,7 @@ namespace RedmineApi.Core
                 ? httpClientHandler.SetAuthentication(auth).Build()
                 : DefaultRedmineHttpSettings.Create().SetAuthentication(auth).Build();
             redmineHttp = new RedmineHttpClient(clientHandler, mimeType);
+            redmineHttp.Authentication = auth;
         }
 
         public MimeType MimeType { get; }


### PR DESCRIPTION
It looks like basic authentication header is set in HttpClient, not in HttpClientHandler, and it wasn't passed to it.

This should enable basic authentication - tested on my local Redmine instance.